### PR TITLE
go_tool: update go_tool_binary to support go 1.12+

### DIFF
--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -206,7 +206,7 @@ def _go_local_sdk_impl(ctx):
 
 _go_local_sdk = repository_rule(
     _go_local_sdk_impl,
-    environ = ["GOROOT"],
+    environ = ["GOROOT", "GOCACHE"],
 )
 
 def go_repositories():


### PR DESCRIPTION
tested on commom/protos

SUBCOMMAND: # @io_bazel_rules_go//go/tools/filter_exec:filter_exec [action 'Executing genrule @io_bazel_rules_go//go/tools/filter_exec:filter_exec [for host]']
(cd /private/var/tmp/_bazel_lenage/9643b246fad34c1c5881e264d9c030e9/execroot/com_llsapp_git_common_protos && \
  exec env - \
    PATH=... \
  /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; GOROOT=$(cd $(dirname external/io_bazel_rules_go_toolchain/bin/go)/..; pwd) GOCACHE=$(cd $(dirname external/io_bazel_rules_go_toolchain/bin/go)/..; mkdir .gocache; cd .gocache; pwd) external/io_bazel_rules_go_toolchain/bin/go build -o bazel-out/host/genfiles/external/io_bazel_rules_go/go/tools/filter_exec/filter_exec_bin external/io_bazel_rules_go/go/tools/filter_exec/filter_exec.go')
SUBCOMMAND: # @io_bazel_rules_go//go/tools/builders:asm [action 'Executing genrule @io_bazel_rules_go//go/tools/builders:asm [for host]']
(cd /private/var/tmp/_bazel_lenage/9643b246fad34c1c5881e264d9c030e9/execroot/com_llsapp_git_common_protos && \
  exec env - \
    PATH=... \
  /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; GOROOT=$(cd $(dirname external/io_bazel_rules_go_toolchain/bin/go)/..; pwd) GOCACHE=$(cd $(dirname external/io_bazel_rules_go_toolchain/bin/go)/..; mkdir .gocache; cd .gocache; pwd) external/io_bazel_rules_go_toolchain/bin/go build -o bazel-out/host/genfiles/external/io_bazel_rules_go/go/tools/builders/asm_bin external/io_bazel_rules_go/go/tools/builders/asm.go external/io_bazel_rules_go/go/tools/builders/filter.go')

INFO: Elapsed time: 949.984s, Critical Path: 77.68s
INFO: 5279 processes: 5069 darwin-sandbox, 210 worker.
INFO: Build completed successfully, 5295 total actions